### PR TITLE
fix: tooltip 组件问题修复#/522

### DIFF
--- a/components/tooltip/style/index.scss
+++ b/components/tooltip/style/index.scss
@@ -1,6 +1,7 @@
 .hi-tooltip {
   position: relative;
   display: inline-block;
+  vertical-align: middle;
 }
 
 .hi-tooltip-base {


### PR DESCRIPTION
该问题由于inline-block元素的宽高不准确，从而导致tooltip组件边缘hover事件频繁触发，加上vertical-align: middle；以后，问题得以解决。
提交人 前端组-陈樟栋