### PR TITLE
feat: add editor disable control

### DIFF
--- a/libs/doc-viewer/components/EditorWrapper.jsx
+++ b/libs/doc-viewer/components/EditorWrapper.jsx
@@ -49,7 +49,7 @@ export default class EditorWrapper extends React.Component {
   render () {
     const { copyed, innerHeight, descBarHeight } = this.state
     const {
-      live: { theme, code, language, disabled },
+      live: { theme, code, language },
       desc,
       prefix
     } = this.props
@@ -126,7 +126,7 @@ export default class EditorWrapper extends React.Component {
             theme={theme}
             code={code}
             language={language}
-            disabled={disabled}
+            disabled={!this.state.collapse}
             onChange={this.onCodeChange}
           />
         </div>


### PR DESCRIPTION
增加 LiveEditor 的禁用状态控制：展开时可用，收起时禁用。这样做是为了防止在组件测试时不停按 <kbd>Tab</kbd> 键会聚焦到代码框里的显示错误。