### PR TITLE
fix(tree): 修复清除搜索条件无法收缩问题

### DIFF
--- a/components/tree/tree-legacy/util.js
+++ b/components/tree/tree-legacy/util.js
@@ -293,7 +293,7 @@ export const getAncestorIds = (id, data, arr = []) => {
 // 收集所有需要展开的节点 id
 export const collectExpandId = (data, searchValue, collection = [], allData) => {
   data.forEach(item => {
-    if (item.title.includes(searchValue)) {
+    if (searchValue && item.title.includes(searchValue)) {
       const parentIds = getAncestorIds(item.id, allData, [])
       collection.splice(collection.length - 1, 0, ...parentIds)
     }

--- a/components/tree/util.js
+++ b/components/tree/util.js
@@ -293,7 +293,7 @@ export const getAncestorIds = (id, data, arr = []) => {
 // 收集所有需要展开的节点 id
 export const collectExpandId = (data, searchValue, collection = [], allData) => {
   data.forEach(item => {
-    if (item.title.includes(searchValue)) {
+    if (searchValue && item.title.includes(searchValue)) {
       const parentIds = getAncestorIds(item.id, allData, [])
       collection.splice(collection.length - 1, 0, ...parentIds)
     }


### PR DESCRIPTION
Fix #599 

当清除搜索条件后，`searchValue` 为空字符串，此时 `item.title.includes(searchValue)` 为`true`，导致将当前节点加入需展开节点数组中，后续进行收缩判断时发生错误，导致点击无法收缩