### PR TITLE
chore: update version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 更新日志
 
+## 2.5.0
+
+- 新增 `<Cascader />` filterOption 属性支持自定义搜索 [#704](https://github.com/XiaoMi/hiui/issues/704)
+- 修复 `<Cascader />` 刷新后 value 不能正确显示的问题 [#667](https://github.com/XiaoMi/hiui/issues/667)
+- 修复 `<Pagination />` pageSizeOptions 写法兼容性问题  [#703](https://github.com/XiaoMi/hiui/issues/703)
+- 修复 `<Carousel />` 第一张图向前翻页跳转不正确的问题 [#696](https://github.com/XiaoMi/hiui/issues/696)
+- 修复 兼容属性 legacy 造成的组件污染问题 [#708](https://github.com/XiaoMi/hiui/issues/708)
+- 修复 `<DatePicker />` 传入字符串值时控制台抛出的警告问题 [#709](https://github.com/XiaoMi/hiui/issues/709)
+
 ## 2.4.1
 
 - 修复 `<Table />` 多选失效的问题 [#699](https://github.com/XiaoMi/hiui/issues/699)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - 修复 `<Carousel />` 第一张图向前翻页跳转不正确的问题 [#696](https://github.com/XiaoMi/hiui/issues/696)
 - 修复 兼容属性 legacy 造成的组件污染问题 [#708](https://github.com/XiaoMi/hiui/issues/708)
 - 修复 `<DatePicker />` 传入字符串值时控制台抛出的警告问题 [#709](https://github.com/XiaoMi/hiui/issues/709)
+- 修复 `<Table />` 列冻结情况下容器宽度大于可滚动宽度的展示不正确的问题 [#718](https://github.com/XiaoMi/hiui/issues/718)
 
 ## 2.4.1
 

--- a/components/date-picker/style/index.scss
+++ b/components/date-picker/style/index.scss
@@ -360,6 +360,7 @@ $basic-color: #4284f5 !default;
 
     p {
       cursor: pointer;
+      margin: 21px 0;
     }
   }
 

--- a/docs/zh-CN/components/changelog.mdx
+++ b/docs/zh-CN/components/changelog.mdx
@@ -1,5 +1,14 @@
 # 更新日志
 
+## 2.5.0
+
+- 新增 `<Cascader />` filterOption 属性支持自定义搜索 [#704](https://github.com/XiaoMi/hiui/issues/704)
+- 修复 `<Cascader />` 刷新后 value 不能正确显示的问题 [#667](https://github.com/XiaoMi/hiui/issues/667)
+- 修复 `<Pagination />` pageSizeOptions 写法兼容性问题  [#703](https://github.com/XiaoMi/hiui/issues/703)
+- 修复 `<Carousel />` 第一张图向前翻页跳转不正确的问题 [#696](https://github.com/XiaoMi/hiui/issues/696)
+- 修复 兼容属性 legacy 造成的组件污染问题 [#708](https://github.com/XiaoMi/hiui/issues/708)
+- 修复 `<DatePicker />` 传入字符串值时控制台抛出的警告问题 [#709](https://github.com/XiaoMi/hiui/issues/709)
+
 ## 2.4.1
 
 - 修复 `<Table />` 多选失效的问题 [#699](https://github.com/XiaoMi/hiui/issues/699)

--- a/docs/zh-CN/components/changelog.mdx
+++ b/docs/zh-CN/components/changelog.mdx
@@ -8,6 +8,7 @@
 - 修复 `<Carousel />` 第一张图向前翻页跳转不正确的问题 [#696](https://github.com/XiaoMi/hiui/issues/696)
 - 修复 兼容属性 legacy 造成的组件污染问题 [#708](https://github.com/XiaoMi/hiui/issues/708)
 - 修复 `<DatePicker />` 传入字符串值时控制台抛出的警告问题 [#709](https://github.com/XiaoMi/hiui/issues/709)
+- 修复 `<Table />` 列冻结情况下容器宽度大于可滚动宽度的展示不正确的问题 [#718](https://github.com/XiaoMi/hiui/issues/718)
 
 ## 2.4.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hi-ui/hiui",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "HIUI for React",
   "scripts": {
     "test": "node_modules/.bin/standard && node_modules/.bin/stylelint --config .stylelintrc 'components/**/*.scss'",


### PR DESCRIPTION
## 2.5.0

- 新增 `<Cascader />` filterOption 属性支持自定义搜索 [#704](https://github.com/XiaoMi/hiui/issues/704)
- 修复 `<Cascader />` 刷新后 value 不能正确显示的问题 [#667](https://github.com/XiaoMi/hiui/issues/667)
- 修复 `<Pagination />` pageSizeOptions 写法兼容性问题  [#703](https://github.com/XiaoMi/hiui/issues/703)
- 修复 `<Carousel />` 第一张图向前翻页跳转不正确的问题 [#696](https://github.com/XiaoMi/hiui/issues/696)
- 修复 兼容属性 legacy 造成的组件污染问题 [#708](https://github.com/XiaoMi/hiui/issues/708)
- 修复 `<DatePicker />` 传入字符串值时控制台抛出的警告问题 [#709](https://github.com/XiaoMi/hiui/issues/709)
- 修复 `<Table />` 列冻结情况下容器宽度大于可滚动宽度的展示不正确的问题 [#718](https://github.com/XiaoMi/hiui/issues/718)