### PR TITLE
2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+## 2.5.2
+
+- 修复 `<Tabs />` 编辑模式下删除最后一个 tab 报错的问题 [#735](https://github.com/XiaoMi/hiui/issues/735)
+- 修复 `<Select />` value 解析不正确的问题 [#737](https://github.com/XiaoMi/hiui/issues/737)
+- 修复 `<Cascader />` 搜索后结果展示宽度太窄的问题 [#721](https://github.com/XiaoMi/hiui/issues/721)
+
 ## 2.5.1
 
 - 修复 `<Input />` defaultValue 设置无效的问题 [#717](https://github.com/XiaoMi/hiui/issues/717)

--- a/docs/zh-CN/components/changelog.mdx
+++ b/docs/zh-CN/components/changelog.mdx
@@ -1,5 +1,11 @@
 # 更新日志
 
+## 2.5.2
+
+- 修复 `<Tabs />` 编辑模式下删除最后一个 tab 报错的问题 [#735](https://github.com/XiaoMi/hiui/issues/735)
+- 修复 `<Select />` value 解析不正确的问题 [#737](https://github.com/XiaoMi/hiui/issues/737)
+- 修复 `<Cascader />` 搜索后结果展示宽度太窄的问题 [#721](https://github.com/XiaoMi/hiui/issues/721)
+
 ## 2.5.1
 
 - 修复 `<Input />` defaultValue 设置无效的问题 [#717](https://github.com/XiaoMi/hiui/issues/717)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hi-ui/hiui",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "HIUI for React",
   "scripts": {
     "test": "node_modules/.bin/standard && node_modules/.bin/stylelint --config .stylelintrc 'components/**/*.scss'",


### PR DESCRIPTION
## 2.5.2

- 修复 `<Tabs />` 编辑模式下删除最后一个 tab 报错的问题 [#735](https://github.com/XiaoMi/hiui/issues/735)
- 修复 `<Select />` value 解析不正确的问题 [#737](https://github.com/XiaoMi/hiui/issues/737)
- 修复 `<Cascader />` 搜索后结果展示宽度太窄的问题 [#721](https://github.com/XiaoMi/hiui/issues/721)