### PR TITLE
fix: tree组件设置draggable失效

### DIFF
--- a/components/tree/tree-legacy/tree-v2/Tree.js
+++ b/components/tree/tree-legacy/tree-v2/Tree.js
@@ -234,11 +234,12 @@ export class Tree extends Component {
   }
 }
 
+const DraggableTree = withDragDropContext(Tree)
+
 const HOCTree = TreeComponent => {
   return class WrapperTree extends Component {
     render () {
       const { draggable } = this.props
-      const DraggableTree = withDragDropContext(Tree)
       return draggable ? <DraggableTree {...this.props} /> : <TreeComponent {...this.props} />
     }
   }


### PR DESCRIPTION
将赋值移除组件，避免重新赋值，组件重新渲染