### PR TITLE
fix: 修复tabs组件flex被压缩过小导致不可点击

### DIFF
--- a/components/tabs/style/index.scss
+++ b/components/tabs/style/index.scss
@@ -389,7 +389,8 @@ $prefix: 'hi-tabs' !default;
     .#{$prefix}__scroll__icon {
       cursor: pointer;
       display: flex;
-      font-size: 40px;
+      font-size: 16px;
+      flex-shrink: 0;
       justify-content: center;
       align-items: center;
       color: use-color('gray-80');


### PR DESCRIPTION
close #1978 