### PR TITLE
fix(space):修复item宽度问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ es/
 .idea/
 .settings/
 .tmp/
+.history/
 
 packages/*/test/coverage/
 # Dev dependencies and cache files
@@ -30,6 +31,7 @@ yarn-error.log
 .turbo
 build/**
 dist/**
+dist-github/**
 .next/**
 
 storybook-static

--- a/packages/ui/space/src/styles/space.scss
+++ b/packages/ui/space/src/styles/space.scss
@@ -4,4 +4,8 @@ $prefix: '#{$component-prefix}-space' !default;
 
 .#{$prefix} {
   display: inline-flex;
+
+  &__item {
+    width: 100%;
+  }
 }

--- a/packages/ui/space/stories/auto-size.stories.tsx
+++ b/packages/ui/space/stories/auto-size.stories.tsx
@@ -22,7 +22,7 @@ export const AutoSize = () => {
           <Switch checked={checked} onChange={(checked) => setChecked(checked)} />
 
           <div>间距调整</div>
-          <Counter autoFocus value={size} min={0} onChange={(v) => setSize(v)} />
+          <Counter value={size} min={0} onChange={(v) => setSize(v)} />
 
           <Space size={nextSize}>
             <Button>HiUI Button</Button>


### PR DESCRIPTION
1.设置item宽度为100%；
2.修改示例“自定义间距大小”，去掉 Counter 组件的 autoFocus 防止每次打开页面时会锚点到该位置；
3.git忽略文件中增加了2项规则：.history/ dist-github/**