### PR TITLE
fix(table): 修复列较多超出容器时空状态显示异常

### DIFF
--- a/packages/ui/table/src/TableBody.tsx
+++ b/packages/ui/table/src/TableBody.tsx
@@ -121,6 +121,7 @@ export const TableBody = forwardRef<HTMLDivElement | null, TableBodyProps>(
                 className: `${prefixCls}-empty-content`,
                 colSpan: columns.length,
                 emptyContent,
+                scrollBodyWidth: scrollBodyElementRef.current?.clientWidth,
               })
             )}
           </tbody>
@@ -152,14 +153,27 @@ const renderEmptyContent = ({
   className,
   colSpan,
   emptyContent,
+  scrollBodyWidth,
 }: {
   colSpan?: number
   className?: string
   emptyContent: React.ReactNode
+  scrollBodyWidth?: number
 }) => {
   return (
     <tr className={className}>
-      <td colSpan={colSpan}>{emptyContent || <EmptyState />}</td>
+      <td colSpan={colSpan}>
+        <div
+          style={{
+            position: 'sticky',
+            left: 0,
+            width: scrollBodyWidth ?? '100%',
+            overflow: 'hidden',
+          }}
+        >
+          {emptyContent || <EmptyState />}
+        </div>
+      </td>
     </tr>
   )
 }


### PR DESCRIPTION
closed #2220 

列较多超出容器时，空状态内容显示在容器外，要让空状态内容一直显示在可见容器的中间，需要做2点改造：
1.在空状态内容外面包一层 div，动态设置该 div 宽度和可见容器宽度一致
2.给该 div 设置为 sticky 布局，且 left 值为0