### PR TITLE
feat(modal): 增加打开动画结束时的回调函数参数

### DIFF
--- a/packages/ui/modal/src/Modal.tsx
+++ b/packages/ui/modal/src/Modal.tsx
@@ -47,6 +47,7 @@ export const Modal = forwardRef<HTMLDivElement | null, ModalProps>(
       closeable = true,
       timeout = 300,
       type,
+      onEntered,
       onExited: onExitedProp,
       title,
       cancelText: cancelTextProp,
@@ -128,6 +129,7 @@ export const Modal = forwardRef<HTMLDivElement | null, ModalProps>(
           in={transitionVisible}
           timeout={timeout}
           appear
+          onEntered={onEntered}
           onExited={onExited}
           mountOnEnter={!preload}
           unmountOnExit={unmountOnClose}
@@ -300,6 +302,11 @@ export interface ModalProps extends HiBaseHTMLProps<'div'>, UseModalProps {
    * @private
    */
   onExited?: () => void
+  /**
+   * 打开动画显示时回调。暂不对外暴露
+   * @private
+   */
+  onEntered?: () => void
   /**
    * 确认框类型
    */


### PR DESCRIPTION
closed #2241 

1.由于弹窗打开动画使用了缩放，导致内容中有动态计算宽高的场景下，计算出的值不是正常的元素大小
2.增加了 onEntered API 在打开动画结束时，用户自行在该回调函数中处理（例如：刷新一遍组件）