### PR TITLE
Hotfix/#2254

### DIFF
--- a/packages/ui/counter/src/use-counter.ts
+++ b/packages/ui/counter/src/use-counter.ts
@@ -254,9 +254,7 @@ export const useCounter = ({
       'aria-valuenow': value,
       'aria-valuemin': minProp,
       'aria-valuemax': maxProp,
-      // 如果 value 变量不是数字，去掉 inputValue 非数字字符，并且将 inputValue 绑定到 value 属性（此时 react input 组件会刷新，从而也就无法输入中文）
-      // 如果 value 变量是数字，则直接将 value 变量绑定到 value 属性，由于 onChange 里面改变的是该 value 的值，此时 react 内部不会刷新 input，可以解决修改任意位置的值时光标都会定位到末尾的问题
-      value: isNaN(value) ? String(inputValue).replace(/\D/g, '') : value,
+      value: String(value).replace(/[^0-9.]/g, ''),
       tabIndex,
       autoFocus: autoFocus,
       disabled: disabled,
@@ -271,7 +269,6 @@ export const useCounter = ({
     minProp,
     maxProp,
     value,
-    inputValue,
     tabIndex,
     autoFocus,
     disabled,

--- a/packages/ui/counter/src/use-counter.ts
+++ b/packages/ui/counter/src/use-counter.ts
@@ -68,13 +68,17 @@ export const useCounter = ({
 
   const inputNumericRef = useRef<number>(value)
 
+  // useEffect(() => {
+  //   setInputValue(value)
+  // }, [value])
+
   useEffect(() => {
-    setInputValue(value)
-  }, [value])
+    tryChangeValue(value)
+  }, [tryChangeValue, value])
 
   // 如果是数值类型，则立即进行修改原始值，保证输入错误也能显示最接近的正确值
-  if (isNumeric(inputValue)) {
-    inputNumericRef.current = Number(inputValue)
+  if (isNumeric(value)) {
+    inputNumericRef.current = Number(value)
   }
 
   const getCurrentValue = useCallback(() => {
@@ -254,7 +258,7 @@ export const useCounter = ({
       'aria-valuenow': value,
       'aria-valuemin': minProp,
       'aria-valuemax': maxProp,
-      value: String(value).replace(/[^0-9.]/g, ''),
+      value,
       tabIndex,
       autoFocus: autoFocus,
       disabled: disabled,

--- a/packages/ui/counter/src/use-counter.ts
+++ b/packages/ui/counter/src/use-counter.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react'
+import React, { useEffect, useCallback, useRef } from 'react'
 import { plus, minus } from 'number-precision'
 import { cx } from '@hi-ui/classname'
 import { invariant } from '@hi-ui/env'
@@ -35,8 +35,6 @@ export const useCounter = ({
 
   const [value, tryChangeValue] = useUncontrolledState(defaultValue, valueProp, onChange, Object.is)
 
-  const [inputValue, setInputValue] = useState<React.ReactText>(value)
-
   const valueRef = useLatestRef(value)
 
   const proxyTryChangeValue = useCallback(
@@ -52,9 +50,6 @@ export const useCounter = ({
       }
 
       tryChangeValue(nextValue)
-      if (syncInput) {
-        setInputValue(nextValue)
-      }
     },
     [disabled, max, min, tryChangeValue]
   )
@@ -68,15 +63,8 @@ export const useCounter = ({
 
   const inputNumericRef = useRef<number>(value)
 
-  // useEffect(() => {
-  //   setInputValue(value)
-  // }, [value])
-
-  useEffect(() => {
-    tryChangeValue(value)
-  }, [tryChangeValue, value])
-
   // 如果是数值类型，则立即进行修改原始值，保证输入错误也能显示最接近的正确值
+  // 最终 input 显示的值是基于 inputNumericRef.current
   if (isNumeric(value)) {
     inputNumericRef.current = Number(value)
   }

--- a/packages/ui/counter/src/use-counter.ts
+++ b/packages/ui/counter/src/use-counter.ts
@@ -254,7 +254,9 @@ export const useCounter = ({
       'aria-valuenow': value,
       'aria-valuemin': minProp,
       'aria-valuemax': maxProp,
-      value: inputValue as string,
+      // 如果 value 变量不是数字，去掉 inputValue 非数字字符，并且将 inputValue 绑定到 value 属性（此时 react input 组件会刷新，从而也就无法输入中文）
+      // 如果 value 变量是数字，则直接将 value 变量绑定到 value 属性，由于 onChange 里面改变的是该 value 的值，此时 react 内部不会刷新 input，可以解决修改任意位置的值时光标都会定位到末尾的问题
+      value: isNaN(value) ? String(inputValue).replace(/\D/g, '') : value,
       tabIndex,
       autoFocus: autoFocus,
       disabled: disabled,


### PR DESCRIPTION
closed #2254 

修改 @hi-ui/counter 中对 value 值的处理方式：
1.修改 input value 绑定值不在为 inputValue，这种方式会导致每次输入 input 都会刷新 2 便，从而导致光标每次输入都定位到末尾
2.修改 input value 绑定值不在为 value，去掉 inputValue 逻辑