### PR TITLE
fix(table): 修复onLoadChildren bug

### DIFF
--- a/packages/ui/table/src/hooks/use-async-switch.ts
+++ b/packages/ui/table/src/hooks/use-async-switch.ts
@@ -4,11 +4,17 @@ import { TableRowEventData } from '../types'
 import { addChildrenById, cloneTree } from '@hi-ui/tree-utils'
 import { useCheckState } from '@hi-ui/use-check-state'
 
-export const useAsyncSwitch = (
-  setCascaderData: React.Dispatch<React.SetStateAction<any[]>>,
-  onExpand?: (selectedOption: TableRowEventData, onlyExpand: boolean) => void,
+export const useAsyncSwitch = ({
+  setCascaderData,
+  onExpand,
+  onLoadChildren,
+  fieldKey = 'key',
+}: {
+  setCascaderData: React.Dispatch<React.SetStateAction<any[]>>
+  onExpand?: (selectedOption: TableRowEventData, onlyExpand: boolean) => void
   onLoadChildren?: (item: TableRowEventData) => Promise<any[] | void> | void
-) => {
+  fieldKey?: string
+}) => {
   const onLoadChildrenLatest = useLatestCallback(onLoadChildren)
 
   // 加载节点
@@ -19,13 +25,13 @@ export const useAsyncSwitch = (
       if (Array.isArray(childrenNodes)) {
         setCascaderData((prev) => {
           const nextTreeData = cloneTree(prev)
-          addChildrenById(nextTreeData, node.id, childrenNodes, 'key')
+          addChildrenById(nextTreeData, node.id, childrenNodes, fieldKey)
 
           return nextTreeData
         })
       }
     },
-    [onLoadChildrenLatest, setCascaderData]
+    [fieldKey, onLoadChildrenLatest, setCascaderData]
   )
 
   const { state: loadingIds, add: addLoadingIds, remove: removeLoadingIds } = useCheckState<

--- a/packages/ui/table/src/styles/table.scss
+++ b/packages/ui/table/src/styles/table.scss
@@ -133,6 +133,7 @@ $prefix: '#{$component-prefix}-table' !default;
       background-clip: padding-box;
 
       &-handle {
+        box-sizing: content-box;
         position: absolute;
         width: 2px;
         height: 100%;

--- a/packages/ui/table/src/use-table.ts
+++ b/packages/ui/table/src/use-table.ts
@@ -119,11 +119,12 @@ export const useTable = ({
   )
 
   // 异步展开子树
-  const [isLoadingTreeNodeId, onTreeNodeSwitch] = useAsyncSwitch(
-    setCacheData,
-    onExpandTreeRowsChange,
-    onLoadChildren
-  )
+  const [isLoadingTreeNodeId, onTreeNodeSwitch] = useAsyncSwitch({
+    setCascaderData: setCacheData,
+    onExpand: onExpandTreeRowsChange,
+    onLoadChildren,
+    fieldKey,
+  })
 
   // ************************ 拖拽 ************************ //
 

--- a/packages/ui/table/stories/on-load-children.stories.tsx
+++ b/packages/ui/table/stories/on-load-children.stories.tsx
@@ -81,7 +81,7 @@ export const OnLoadChildren = () => {
       size: '6G+64G 幻彩蓝',
       price: '699.00',
       address: '双安店',
-      stock: '12,000',
+      stock: '13,000',
       key: 5,
     },
   ])
@@ -93,6 +93,7 @@ export const OnLoadChildren = () => {
         <Table
           columns={columns}
           data={data}
+          fieldKey="stock"
           onLoadChildren={(item) => {
             const { depth } = item
             console.log('item', item)
@@ -109,7 +110,7 @@ export const OnLoadChildren = () => {
                       size: '6G+64G',
                       price: '3299.00',
                       address: '华润五彩城店',
-                      stock: '29,000',
+                      stock: '100',
                       key: new Date().getTime(),
                     },
                     {
@@ -118,7 +119,7 @@ export const OnLoadChildren = () => {
                       size: '6G+64G',
                       price: '3299.00',
                       address: '华润五彩城店',
-                      stock: '29,000',
+                      stock: '200',
                       key: new Date().getTime() + 1,
                     },
                   ]


### PR DESCRIPTION
closed #2263 

修改点：
1.增加子节点的算法，基于动态的fieldKey参数的值来判断
2.顺带修改了一个样式问题：如果全局设置了box-sizing: border-box，会导致resizable模式下的操作条不展示