### PR TITLE
fix(form): 处理校验器接收的字符串数字类型（#2268）

### DIFF
--- a/packages/ui/form/src/use-form-field.ts
+++ b/packages/ui/form/src/use-form-field.ts
@@ -40,7 +40,10 @@ export const useFormField = <Values = any>(props: UseFormFieldProps<Values>) => 
       const fieldMD5 = stringify(field as FormFieldPath)
 
       const validater = new Validater({ [fieldMD5]: fieldRules })
-      return validater.validate({ [fieldMD5]: value }, { firstFields: true })
+      return validater.validate(
+        { [fieldMD5]: isNaN(value as number) ? value : Number(value) },
+        { firstFields: true }
+      )
     },
     [fieldRules, field]
   )

--- a/packages/ui/form/stories/basic.stories.tsx
+++ b/packages/ui/form/stories/basic.stories.tsx
@@ -13,7 +13,7 @@ export const Basic = () => {
       <h1>Basic</h1>
       <div className="form-basic__wrap" style={{ width: 400 }}>
         <Form
-          initialValues={{ testInput: 'testInput', testInput2: 'testInput2' }}
+          initialValues={{ testInput: 1, testInput2: 'testInput2' }}
           // validateTrigger={['onBlur']}
           labelWidth={80}
           rules={{
@@ -21,9 +21,9 @@ export const Basic = () => {
               {
                 // name: 'max',
                 // strategy: 10,
-                max: 10,
-                type: 'string',
-                message: 'max is 10',
+                max: 100,
+                type: 'number',
+                message: 'max is 100',
               },
             ],
             testInput2: [
@@ -37,7 +37,7 @@ export const Basic = () => {
             ],
           }}
         >
-          <FormItem field="testInput" valueType="string" label="用户名">
+          <FormItem field="testInput" valueType="number" label="用户名">
             <Input onChange={console.log} />
           </FormItem>
           <FormItem field="testInput2" valueType="string" label="密码">


### PR DESCRIPTION
closed #2268 

问题原因：
在输入框中，fieldValidate 方法中接收的 value 的类型总是 string，导致字段校验设置为 number 类型总是不通过

修改点：
1.判断 fieldValidate 方法中接收的 value 如果是字符串数字则将其转换为数字类型