### PR TITLE
fix(notification): 修改icon样式

### DIFF
--- a/packages/ui/notification/src/styles/notification.scss
+++ b/packages/ui/notification/src/styles/notification.scss
@@ -40,10 +40,10 @@ $prefix: '#{$component-prefix}-notification' !default;
     display: flex;
     align-items: center;
     margin-right: use-spacing(6);
+    font-size: use-text-size('xxl');
 
     svg {
       flex-shrink: 0;
-      font-size: use-text-size('xxl');
     }
   }
 


### PR DESCRIPTION
closed #2273 

问题原因：
之前设置的icon大小是设置的svg的font-size，当svg的样式有别的模块给覆盖时，导致icon大小设置不生效

解决方案：
不在svg上面设置font-size，设置它的父节点的font-size