### PR TITLE
fix(time-picker): 修复初始值显示格式问题

### DIFF
--- a/packages/ui/time-picker/src/TimePicker.tsx
+++ b/packages/ui/time-picker/src/TimePicker.tsx
@@ -28,12 +28,15 @@ const DefaultValue = ['', ''] as TimePickerValue[]
 const DefaultDisabledFunc = () => []
 const DefaultPlaceholder = ['', '']
 
-const getValueMatchString = (value?: TimePickerValue[] | TimePickerValue) => {
+const getValueMatchString = (
+  value?: TimePickerValue[] | TimePickerValue,
+  format: TimePickerFormat = 'HH:mm:ss'
+) => {
   if (!value) {
     return undefined
   }
   const result = Array.isArray(value) ? value : [value]
-  return result.map((item) => (typeof item === 'string' ? item : DayJs(item).format('HH:mm:ss')))
+  return result.map((item) => (typeof item === 'string' ? item : DayJs(item).format(format)))
 }
 
 export const TimePicker = forwardRef<HTMLDivElement | null, TimePickerProps>(
@@ -71,11 +74,13 @@ export const TimePicker = forwardRef<HTMLDivElement | null, TimePickerProps>(
     const nowText = i18n.get('timePicker.now')
 
     const [attachEl, setAttachEl] = useState<HTMLElement | null>(null)
-    const formatUncontrolledValue = useMemo(() => getValueMatchString(uncontrolledValue)!, [
+    const formatUncontrolledValue = useMemo(() => getValueMatchString(uncontrolledValue, format)!, [
+      format,
       uncontrolledValue,
     ])
-    const formatControlledValue = useMemo(() => getValueMatchString(controlledValue), [
+    const formatControlledValue = useMemo(() => getValueMatchString(controlledValue, format), [
       controlledValue,
+      format,
     ])
     const formatNotifyOutside = useCallback(
       (disposeValue: string[]) => {


### PR DESCRIPTION
closed #2277 

问题原因：
处理初始值，固定是按照 HH:mm:ss 格式去处理，没有按照用户传入的 format 来处理，所以如果传入时间戳时，返回的是时分秒的格式。

解决方案：
给处理初始值的函数中传入用户传入的 format，按照 format 来格式化，默认是按照 HH:mm:ss 格式处理