### PR TITLE
fix:修复selectree 无法再次选择相同值问题

### DIFF
--- a/components/select-tree/SelectTreeHook.js
+++ b/components/select-tree/SelectTreeHook.js
@@ -273,7 +273,7 @@ const SelectTree = ({
       checked: [],
       semiChecked: []
     })
-    onChange && onChange()
+    onChange && onChange('')
   }, [onChange])
 
   /**


### PR DESCRIPTION
当选择一个值，在选择clear 按钮删除后，再次选择上一个值选择不上的问题