### PR TITLE
fix: measure row bindlogic and virtual width logic

### DIFF
--- a/packages/ui/table/src/TableBody.tsx
+++ b/packages/ui/table/src/TableBody.tsx
@@ -20,7 +20,7 @@ export const TableBody = forwardRef<HTMLDivElement | null, TableBodyProps>(
     const {
       columns,
       leafColumns,
-      measureRowElementRef,
+      setMeasureRowElement,
       isExpandTreeRows,
       transitionData,
       getColgroupProps,
@@ -91,7 +91,12 @@ export const TableBody = forwardRef<HTMLDivElement | null, TableBodyProps>(
             overflowX: canScroll ? 'scroll' : undefined,
           }}
         >
-          <div ref={measureRowElementRef} style={{ height: 1, background: 'transparent' }}></div>
+          <div
+            ref={(domElement) => {
+              setMeasureRowElement(domElement)
+            }}
+            style={{ height: 1, background: 'transparent' }}
+          ></div>
           <div
             ref={bodyTableRef}
             style={{ height: 1, background: 'transparent', width: rowWidth }}
@@ -159,7 +164,11 @@ export const TableBody = forwardRef<HTMLDivElement | null, TableBodyProps>(
                 {transitionData.map((row, index) => {
                   return (
                     <TableRow
-                      ref={index === 0 ? measureRowElementRef : null}
+                      ref={(dom) => {
+                        if (index === 0) {
+                          setMeasureRowElement(dom)
+                        }
+                      }}
                       // key={depth + index}
                       key={row.id}
                       // @ts-ignore

--- a/packages/ui/table/src/hooks/use-col-width.ts
+++ b/packages/ui/table/src/hooks/use-col-width.ts
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { FlattedTableColumnItemData, TableColumnItem, TableRowRecord } from '../types'
 import { getGroupItemWidth } from '../utils'
 import { useUpdateEffect } from '@hi-ui/use-update-effect'
@@ -21,7 +21,39 @@ export const useColWidth = ({
   })
 
   useUpdateEffect(() => {
-    setColWidths(getGroupItemWidth(columns))
+    if (virtual) {
+      // 虚拟滚动的计算需要根据容器来做分配，不能使用没有witdh默认设置为0的方式来做表格平均分配
+      setColWidths(getVirtualWidths())
+    } else {
+      setColWidths(getGroupItemWidth(columns))
+    }
+  }, [columns, virtual])
+
+  const getVirtualWidths = useCallback(() => {
+    const measureRowElement = measureRowElementRef.current
+    if (!measureRowElement) {
+      return getGroupItemWidth(columns)
+    }
+
+    /** 虚拟滚动时，内容宽度不能用以前table自动渲染的方式获取，需要手动计算 */
+    const columnDefaultWidth = 200
+    const containerWidth = measureRowElement.clientWidth
+    let totalWidth: number = 0
+    /** 虚拟滚动，需要根据collist的虚拟宽度来计算宽度 */
+    columns.forEach((columnItem: TableColumnItem) => {
+      totalWidth += columnItem.width || columnDefaultWidth
+    })
+    if (totalWidth < containerWidth) {
+      // 容器宽度大于设置的宽度总和时，col宽度等比分分配占满容器。
+      return columns.map((columnItem: TableColumnItem) => {
+        return ((columnItem.width || columnDefaultWidth) * containerWidth) / totalWidth
+      })
+    } else {
+      // 容器宽度小于设置的宽度总和时，col宽度等于设置/默认宽度。
+      return columns.map((columnItem: TableColumnItem) => {
+        return columnItem.width || columnDefaultWidth
+      })
+    }
   }, [columns])
 
   /**
@@ -34,29 +66,7 @@ export const useColWidth = ({
     if (measureRowElement) {
       const resizeObserver = new ResizeObserver(() => {
         if (virtual) {
-          /** 虚拟滚动时，内容宽度不能用以前table自动渲染的方式获取，需要手动计算 */
-          const columnDefaultWidth = 200
-          const containerWidth = measureRowElement.clientWidth
-          let totalWidth: number = 0
-          /** 虚拟滚动，需要根据collist的虚拟宽度来计算宽度 */
-          columns.forEach((columnItem: TableColumnItem) => {
-            totalWidth += columnItem.width || columnDefaultWidth
-          })
-          if (totalWidth < containerWidth) {
-            // 容器宽度大于设置的宽度总和时，col宽度等比分分配占满容器。
-            setColWidths(
-              columns.map((columnItem: TableColumnItem) => {
-                return ((columnItem.width || columnDefaultWidth) * containerWidth) / totalWidth
-              })
-            )
-          } else {
-            // 容器宽度小于设置的宽度总和时，col宽度等于设置/默认宽度。
-            setColWidths(
-              columns.map((columnItem: TableColumnItem) => {
-                return columnItem.width || columnDefaultWidth
-              })
-            )
-          }
+          setColWidths(getVirtualWidths())
         } else {
           if (measureRowElement.childNodes) {
             const _realColumnsWidth = Array.from(measureRowElement.childNodes).map((node) => {
@@ -78,7 +88,9 @@ export const useColWidth = ({
         resizeObserver.disconnect()
       }
     }
-  }, [])
+    // 测量元素在内容列为空时会是空，切换会使测量元素变化，导致后续的resize时间无法响应,此处测量元素变化时需要重新绑定
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [measureRowElementRef.current])
 
   const [headerTableElement, setHeaderTableElement] = React.useState<HTMLTableElement | null>(null)
 

--- a/packages/ui/table/src/hooks/use-col-width.ts
+++ b/packages/ui/table/src/hooks/use-col-width.ts
@@ -20,15 +20,6 @@ export const useColWidth = ({
     return getGroupItemWidth(columns)
   })
 
-  useUpdateEffect(() => {
-    if (virtual) {
-      // 虚拟滚动的计算需要根据容器来做分配，不能使用没有witdh默认设置为0的方式来做表格平均分配
-      setColWidths(getVirtualWidths())
-    } else {
-      setColWidths(getGroupItemWidth(columns))
-    }
-  }, [columns, virtual])
-
   const getVirtualWidths = useCallback(() => {
     const measureRowElement = measureRowElementRef.current
     if (!measureRowElement) {
@@ -55,6 +46,15 @@ export const useColWidth = ({
       })
     }
   }, [columns])
+
+  useUpdateEffect(() => {
+    if (virtual) {
+      // 虚拟滚动的计算需要根据容器来做分配，不能使用没有witdh默认设置为0的方式来做表格平均分配
+      setColWidths(getVirtualWidths())
+    } else {
+      setColWidths(getGroupItemWidth(columns))
+    }
+  }, [columns, getVirtualWidths, virtual])
 
   /**
    * 根据实际内容区（table 的第一行）渲染，再次精确收集并设置每列宽度

--- a/packages/ui/table/src/hooks/use-col-width.ts
+++ b/packages/ui/table/src/hooks/use-col-width.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback } from 'react'
 import { FlattedTableColumnItemData, TableColumnItem, TableRowRecord } from '../types'
 import { getGroupItemWidth } from '../utils'
 import { useUpdateEffect } from '@hi-ui/use-update-effect'
@@ -14,14 +14,12 @@ export const useColWidth = ({
   columns: TableColumnItem[]
   virtual?: boolean
 }) => {
-  const measureRowElementRef = useRef<HTMLTableRowElement>(null)
-
+  const [measureRowElement, setMeasureRowElement] = React.useState<Element | null>(null)
   const [colWidths, setColWidths] = React.useState(() => {
     return getGroupItemWidth(columns)
   })
 
   const getVirtualWidths = useCallback(() => {
-    const measureRowElement = measureRowElementRef.current
     if (!measureRowElement) {
       return getGroupItemWidth(columns)
     }
@@ -45,7 +43,7 @@ export const useColWidth = ({
         return columnItem.width || columnDefaultWidth
       })
     }
-  }, [columns])
+  }, [measureRowElement, columns])
 
   useUpdateEffect(() => {
     if (virtual) {
@@ -61,7 +59,6 @@ export const useColWidth = ({
    */
   React.useEffect(() => {
     let resizeObserver: ResizeObserver
-    const measureRowElement = measureRowElementRef.current
 
     if (measureRowElement) {
       const resizeObserver = new ResizeObserver(() => {
@@ -89,7 +86,7 @@ export const useColWidth = ({
       }
     }
     // 测量元素在内容列为空时会是空，切换会使测量元素变化，导致后续的resize时间无法响应,此处测量元素变化时需要重新绑定
-  }, [measureRowElementRef.current, virtual])
+  }, [measureRowElement, virtual])
 
   const [headerTableElement, setHeaderTableElement] = React.useState<HTMLTableElement | null>(null)
 
@@ -160,7 +157,8 @@ export const useColWidth = ({
   )
 
   return {
-    measureRowElementRef,
+    measureRowElement,
+    setMeasureRowElement,
     onColumnResizable,
     getColgroupProps,
     setHeaderTableElement,

--- a/packages/ui/table/src/hooks/use-col-width.ts
+++ b/packages/ui/table/src/hooks/use-col-width.ts
@@ -89,8 +89,7 @@ export const useColWidth = ({
       }
     }
     // 测量元素在内容列为空时会是空，切换会使测量元素变化，导致后续的resize时间无法响应,此处测量元素变化时需要重新绑定
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [measureRowElementRef.current])
+  }, [measureRowElementRef.current, virtual])
 
   const [headerTableElement, setHeaderTableElement] = React.useState<HTMLTableElement | null>(null)
 

--- a/packages/ui/table/src/use-table.ts
+++ b/packages/ui/table/src/use-table.ts
@@ -173,7 +173,7 @@ export const useTable = ({
 
   // ************************ 列宽 resizable ************************ //
 
-  const { measureRowElementRef, getColgroupProps, onColumnResizable, colWidths } = useColWidth({
+  const { setMeasureRowElement, getColgroupProps, onColumnResizable, colWidths } = useColWidth({
     data,
     columns,
     resizable,
@@ -566,7 +566,7 @@ export const useTable = ({
     // 行多选
     rowSelection,
     cacheData,
-    measureRowElementRef,
+    setMeasureRowElement,
     leafColumns,
     // ui
     // 有表头分组那么也要 bordered


### PR DESCRIPTION
1.修改元素宽度自适应bug
-测量元素在切换空/结果列时元素会变化，需要重新绑定对元素resize的监测
2.修改虚拟列表宽度计算逻辑。
-虚拟列表在字段变化时，还是需要通过容器宽度来计算表头宽度