### PR TITLE
fix(drawer): #2485

### DIFF
--- a/.changeset/large-moons-care.md
+++ b/.changeset/large-moons-care.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/hiui": patch
+---
+
+Drawer fix: 修复入场动画问题

--- a/.changeset/nice-parrots-run.md
+++ b/.changeset/nice-parrots-run.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/drawer": patch
+---
+
+fix: 修复入场动画问题

--- a/packages/ui/drawer/package.json
+++ b/packages/ui/drawer/package.json
@@ -54,7 +54,7 @@
     "@hi-ui/use-merge-refs": "^4.0.1",
     "@hi-ui/use-scroll-lock": "^4.0.1",
     "@hi-ui/use-toggle": "^4.0.1",
-    "react-transition-group": "^4.4.2"
+    "react-transition-group": "4.4.2"
   },
   "peerDependencies": {
     "@hi-ui/core": ">=4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15674,7 +15674,7 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-transition-group@^4.4.2:
+react-transition-group@4.4.2, react-transition-group@^4.4.2:
   version "4.4.2"
   resolved "https://registry.nlark.com/react-transition-group/download/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
   dependencies:


### PR DESCRIPTION
closed #2485 

问题原因：依赖的 react-transition-group 版本问题，4.4.5 版本中没有入场动画，4.4.2 版本是正常的
解决方案：将组件中 react-transition-group 的依赖版本固定为 4.4.2