### PR TITLE
perf(icons): #2502

### DIFF
--- a/.changeset/seven-hairs-greet.md
+++ b/.changeset/seven-hairs-greet.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/icons": patch
+---
+
+perf: package.json add sideEffects

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -23,6 +23,7 @@
       "default": "./lib/esm/index.js"
     }
   },
+  "sideEffects": ["*.scss", "*.scss.js", "./lib/*/index.js"],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
closed #2502 

package.json 增加配置： sideEffects: ["*.scss", "*.scss.js", "./lib/*/index.js"]
其中 "*.scss" 是给组件 rollup 打包时标识为副作用的文件，"*.scss.js", "./lib/*/index.js" 是给使用组件打包时标识为副作用的文件