### PR TITLE
ci: 更新CI中的node版本号

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Setup Node.js 14.17.x
+      - name: Setup Node.js 14.21.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.x
+          node-version: 14.21.x
           cache: 'yarn'
 
       - name: Setup npmrc

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Setup Node.js 14.17.x
+      - name: Setup Node.js 14.21.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.17.x
+          node-version: 14.21.x
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
由于升级到rollup3，需要的node版本号要大于14.21.x，所以同步修改CI中的node版本