### PR TITLE
fix(date-picker): 修复datepicker显示农历时2月中1月农历显示错误问题 (#2853)

### DIFF
--- a/.changeset/olive-trains-joke.md
+++ b/.changeset/olive-trains-joke.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/hiui": patch
+---
+
+fix(date-picker): 修复 datepicker 显示农历时 2 月中 1 月农历显示错误问题

--- a/.changeset/tidy-rings-burn.md
+++ b/.changeset/tidy-rings-burn.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/date-picker": patch
+---
+
+fix(date-picker): 修复 datepicker 显示农历时 2 月中 1 月农历显示错误问题(#2853)

--- a/packages/ui/date-picker/src/utils/index.tsx
+++ b/packages/ui/date-picker/src/utils/index.tsx
@@ -198,13 +198,14 @@ export const getFullTime = ({
 }) => {
   if (cell.type === 'disabled') return false
   const newDate = moment(renderDate)
-  newDate.date(cell.value)
+  // 先设置月份，防止赋值出月中不存在日期
   if (cell.type === 'prev') {
     newDate.subtract(1, 'months')
   }
   if (cell.type === 'next') {
     newDate.add(1, 'months')
   }
+  newDate.date(cell.value)
   const _year = newDate.year()
   const _month = newDate.month() + 1
   const _value = cell.value


### PR DESCRIPTION
修改设置日期顺序至修改月份后，防止日期被设置到不存在该日期的月份
closed #2853