### PR TITLE
fix(tree): 修复Firefox中组件拖拽报错问题(#2941)

### DIFF
--- a/.changeset/chilly-squids-talk.md
+++ b/.changeset/chilly-squids-talk.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/tree": patch
+---
+
+fix: 修复 Firefox 中组件拖拽报错问题

--- a/.changeset/lemon-fireants-glow.md
+++ b/.changeset/lemon-fireants-glow.md
@@ -1,0 +1,5 @@
+---
+"@hi-ui/hiui": patch
+---
+
+fix(tree): 修复 Firefox 中组件拖拽报错问题

--- a/packages/ui/tree/src/TreeNode.tsx
+++ b/packages/ui/tree/src/TreeNode.tsx
@@ -92,6 +92,7 @@ export const TreeNode = forwardRef<HTMLLIElement | null, TreeNodeProps>((props, 
 
       const { id } = eventNodeRef.current
 
+      // 清空数据，下面会重新设置
       evt.dataTransfer.clearData()
       evt.stopPropagation()
 
@@ -109,6 +110,8 @@ export const TreeNode = forwardRef<HTMLLIElement | null, TreeNodeProps>((props, 
     (evt: React.DragEvent) => {
       evt.preventDefault()
       evt.stopPropagation()
+      // issue: https://github.com/XiaoMi/hiui/issues/2941
+      // 在firefox中拖拽结束后，清除数据会报错，Modifications are not allowed for this document，所以这里注释掉
       // evt.dataTransfer.clearData()
       dragNodeRef.current = null
       setDirection(null)

--- a/packages/ui/tree/src/TreeNode.tsx
+++ b/packages/ui/tree/src/TreeNode.tsx
@@ -92,6 +92,7 @@ export const TreeNode = forwardRef<HTMLLIElement | null, TreeNodeProps>((props, 
 
       const { id } = eventNodeRef.current
 
+      evt.dataTransfer.clearData()
       evt.stopPropagation()
 
       setIsDragging(true)
@@ -108,7 +109,7 @@ export const TreeNode = forwardRef<HTMLLIElement | null, TreeNodeProps>((props, 
     (evt: React.DragEvent) => {
       evt.preventDefault()
       evt.stopPropagation()
-      evt.dataTransfer.clearData()
+      // evt.dataTransfer.clearData()
       dragNodeRef.current = null
       setDirection(null)
       setIsDragging(false)


### PR DESCRIPTION
closed #2941 