### PR TITLE
fix(dropdown): 修复父节点设置disabled后依然可以点击的问题 (#3030)

### DIFF
--- a/.changeset/rare-needles-hang.md
+++ b/.changeset/rare-needles-hang.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/dropdown": patch
+"@hi-ui/hiui": patch
+---
+
+fix(dropdown): 修复父节点设置 disabled 后依然可以点击的问题 (#3030)

--- a/packages/ui/dropdown/src/Dropdown.tsx
+++ b/packages/ui/dropdown/src/Dropdown.tsx
@@ -270,6 +270,7 @@ const DropdownMenuItem = forwardRef<HTMLLIElement | null, DropdownMenuItemProps>
       ...rest,
       trigger: triggerMethods,
       parents: parentsProp,
+      disabled,
     })
 
     const cls = cx(


### PR DESCRIPTION
closed #3030 