### PR TITLE
fix(scrollbar): 去掉 perfect-scrollbar 依赖

### DIFF
--- a/.changeset/good-comics-smell.md
+++ b/.changeset/good-comics-smell.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/scrollbar": patch
+"@hi-ui/hiui": patch
+---
+
+fix(scrollbar): Scrollbar 组件中去掉 perfect-scrollbar 依赖,因为通过 patch-package 修改了这个库的源码,所以必现将依赖去掉,这样才能将修改的源码打包到 Scrollbar 组件的 lib 中

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "lodash": "^4.17.21",
     "nodemon": "^2.0.12",
     "patch-package": "^6.4.7",
+    "perfect-scrollbar": "1.5.5",
     "pinyin-pro": "^3.15.1",
     "postinstall-postinstall": "^2.1.0",
     "rc-virtual-list": "^3.4.8",

--- a/packages/ui/scrollbar/package.json
+++ b/packages/ui/scrollbar/package.json
@@ -45,8 +45,7 @@
   "dependencies": {
     "@hi-ui/classname": "^4.0.5",
     "@hi-ui/env": "^4.0.5",
-    "@hi-ui/use-merge-refs": "^4.0.4",
-    "perfect-scrollbar": "^1.5.5"
+    "@hi-ui/use-merge-refs": "^4.0.4"
   },
   "peerDependencies": {
     "@hi-ui/core": ">=4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14220,9 +14220,9 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-perfect-scrollbar@^1.5.5:
+perfect-scrollbar@1.5.5:
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
+  resolved "https://registry.npmmirror.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
   integrity sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==
 
 performance-now@^0.2.0:


### PR DESCRIPTION
Scrollbar 组件中去掉 perfect-scrollbar 依赖,因为通过 patch-package 修改了这个库的源码,所以必现将依赖去掉,这样才能将修改的源码打包到 Scrollbar 组件的 lib 中