### PR TITLE
fix(form): 修复特殊场景下 validate() 执行后获取不到最新值问题 (#3120)

### DIFF
--- a/.changeset/quick-teachers-glow.md
+++ b/.changeset/quick-teachers-glow.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/form": patch
+"@hi-ui/hiui": patch
+---
+
+fix(form): 更新 FormItemProps 的 children 类型以支持渲染函数，并修复 useForm 中对 formState 的引用问题 (#3120)

--- a/packages/ui/form/src/FormItem.tsx
+++ b/packages/ui/form/src/FormItem.tsx
@@ -65,7 +65,7 @@ export interface FormItemProps extends UseFormFieldProps, FormLabelProps {
   /**
    * 表单控件或其渲染函数
    */
-  children?: React.ReactNode
+  children?: React.ReactNode | ((props: Record<string, any>) => React.ReactNode)
   /**
    * 支持表单控件 render 渲染
    */

--- a/packages/ui/form/src/use-form.ts
+++ b/packages/ui/form/src/use-form.ts
@@ -433,7 +433,7 @@ export const useForm = <Values = Record<string, any>>({
           let promiseOrUndefined
           try {
             // @ts-ignore
-            promiseOrUndefined = onSubmit?.(formState.values)
+            promiseOrUndefined = onSubmit?.(formStateRef.current.values)
           } catch (error) {
             formDispatch({ type: 'SUBMIT_DONE' })
 
@@ -443,7 +443,7 @@ export const useForm = <Values = Record<string, any>>({
           if (promiseOrUndefined === undefined) {
             formDispatch({ type: 'SUBMIT_DONE' })
             // return combinedErrors
-            return formState.values
+            return formStateRef.current.values
           }
 
           return Promise.resolve(promiseOrUndefined)
@@ -451,7 +451,7 @@ export const useForm = <Values = Record<string, any>>({
               formDispatch({ type: 'SUBMIT_DONE' })
               // return result
               // TODO: 满足promise 如果既给到values 又给到 errors
-              return formState.values
+              return formStateRef.current.values
             })
             .catch((_errors) => {
               formDispatch({ type: 'SUBMIT_DONE' })
@@ -472,7 +472,7 @@ export const useForm = <Values = Record<string, any>>({
         throw error
       }
     )
-  }, [formState, onSubmit, validateAll])
+  }, [formStateRef, onSubmit, validateAll])
 
   const handleSubmit = useCallback(
     (evt?: React.FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
closed #3120 

同步修改：更新 FormItemProps 的 children 类型以支持渲染函数