### PR TITLE
fix(tag-input): 修复 TagInputMock 组件中标签最大数量逻辑及更新 tagsWidth 的处理方式 (#3260)

### DIFF
--- a/.changeset/neat-paws-call.md
+++ b/.changeset/neat-paws-call.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/tag-input": patch
+"@hi-ui/hiui": patch
+---
+
+fix(tag-input): 修复 TagInputMock 组件中标签最大数量逻辑及更新 tagsWidth 的处理方式 (#3260)

--- a/packages/ui/tag-input/src/TagInputMock.tsx
+++ b/packages/ui/tag-input/src/TagInputMock.tsx
@@ -129,19 +129,21 @@ export const TagInputMock = forwardRef<HTMLDivElement | null, TagInputMockProps>
       }
 
       // 保底要展示 1 个
-      setTagMaxCount(isArrayNonEmpty(mergedTagList) && tagMaxCount < 1 ? 1 : tagMaxCount)
+      setTagMaxCount(isArrayNonEmpty(mergedTagList) && tagMaxCount < 1 ? 0 : tagMaxCount)
     }, [tagsWidth, suffixWidth, getTagWidth, containerWidth, mergedTagList, suffix])
 
     // mergedTagList 更新后同步更新 tagsWidth
     useEffect(() => {
-      const updatedTagsWidth: { [key: string]: number } = {}
+      setTagsWidth((prev) => {
+        const updatedTagsWidth: { [key: string]: number } = {}
 
-      mergedTagList.forEach((item) => {
-        const { id } = item
-        updatedTagsWidth[id] = tagsWidth[id] ?? 0
+        mergedTagList.forEach((item) => {
+          const { id } = item
+          updatedTagsWidth[id] = prev[id] ?? 0
+        })
+
+        return updatedTagsWidth
       })
-
-      setTagsWidth(updatedTagsWidth)
     }, [mergedTagList])
 
     const onClearLatest = useLatestCallback(onClear)


### PR DESCRIPTION
closed #3260 