### PR TITLE
fix(EllipsisTooltip): error when text null

### DIFF
--- a/packages/ui/ellipsis-tooltip/src/EllipsisTooltip.tsx
+++ b/packages/ui/ellipsis-tooltip/src/EllipsisTooltip.tsx
@@ -8,7 +8,7 @@ const ELLIPSIS_TOOLTIP_PREFIX = getPrefixCls('ellipsis-tooltip')
 
 // 格式化子文本，超出规定字数时展示...
 const formatChildText = (text: string, maxTextCount: number) => {
-  const stringText = text?.toString()
+  const stringText = text?.toString() || ''
   const canTooltip = maxTextCount > 0 && stringText.length > maxTextCount
   return canTooltip ? `${stringText.slice(0, maxTextCount)}...` : text
 }


### PR DESCRIPTION
<img width="984" height="581" alt="image" src="https://github.com/user-attachments/assets/157b22e6-4e75-49c3-9fbf-0b12329e0974" />

I found that when using EllipsisTooltip, if text is empty and maxTextCount is configured, an error will be reported TypeError: Cannot read properties of undefined (reading 'length')
