### PR TITLE
fix(tag-input): ensure at least one tag is displayed when container width is insufficient (#3449)

### DIFF
--- a/.changeset/early-nails-agree.md
+++ b/.changeset/early-nails-agree.md
@@ -1,0 +1,7 @@
+---
+"@hi-ui/check-select": patch
+"@hi-ui/tag-input": patch
+"@hi-ui/hiui": patch
+---
+
+fix(tag-input): ensure at least one tag is displayed when container width is insufficient (#3449)

--- a/packages/ui/tag-input/src/TagInputMock.tsx
+++ b/packages/ui/tag-input/src/TagInputMock.tsx
@@ -68,7 +68,8 @@ export const TagInputMock = forwardRef<HTMLDivElement | null, TagInputMockProps>
       if (wrap) {
         return tagList
       }
-      return tagList.slice(0, Math.min(tagList.length, containerWidth / tagWidth))
+      const maxCount = Math.min(tagList.length, containerWidth / tagWidth)
+      return tagList.slice(0, maxCount < 1 ? 1 : maxCount)
     }, [tagList, tagWidth, containerWidth, wrap])
 
     const showTags = mergedTagList.length > 0


### PR DESCRIPTION
closed #3449 