### PR TITLE
fix(table): 修复在stretchHeight模式下，冻结列表头和单元格层级问题 (5.0)

### DIFF
--- a/.changeset/curvy-ravens-swim.md
+++ b/.changeset/curvy-ravens-swim.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/hiui": patch
+"@hi-ui/table": patch
+---
+
+fix(table): 修复在 stretchHeight 模式下，冻结列表头和单元格层级问题 (5.0)

--- a/packages/ui/table/src/TableCell.tsx
+++ b/packages/ui/table/src/TableCell.tsx
@@ -105,7 +105,7 @@ export const TableCell = forwardRef<HTMLTableCellElement | null, TableCellProps>
 
     if (virtual) {
       const width = colWidths[colIndex]
-      const colProps = getStickyColProps(column)
+      const colProps = getStickyColProps(column, 'td')
       return (
         <div
           ref={ref}
@@ -144,7 +144,7 @@ export const TableCell = forwardRef<HTMLTableCellElement | null, TableCellProps>
         ref={ref}
         key={dataKey}
         className={cls}
-        {...getStickyColProps(column)}
+        {...getStickyColProps(column, 'td')}
         colSpan={cellContent.props.colSpan}
         rowSpan={cellContent.props.rowSpan}
         // 按需绑定函数，避免频繁调用 setState 特别消耗性能

--- a/packages/ui/table/src/TheadContent.tsx
+++ b/packages/ui/table/src/TheadContent.tsx
@@ -68,7 +68,11 @@ export const TheadContent = forwardRef<HTMLDivElement | null, TheadContentProps>
                   }
                 }
 
-                const stickyColProps = getStickyColProps(col)
+                const stickyColProps = getStickyColProps(
+                  col,
+                  'th',
+                  trRefs.current[colsIndex]?.offsetTop
+                )
 
                 const cell = (
                   <th
@@ -78,7 +82,6 @@ export const TheadContent = forwardRef<HTMLDivElement | null, TheadContentProps>
                       ...stickyColProps.style,
                       // 表头合并场景下，被合并的表头需要隐藏
                       display: col?.colSpan === 0 ? 'none' : undefined,
-                      top: trRefs.current[colsIndex]?.offsetTop,
                     }}
                     className={cx(
                       `${prefixCls}-cell`,

--- a/packages/ui/table/src/TheadContent.tsx
+++ b/packages/ui/table/src/TheadContent.tsx
@@ -68,11 +68,7 @@ export const TheadContent = forwardRef<HTMLDivElement | null, TheadContentProps>
                   }
                 }
 
-                const stickyColProps = getStickyColProps(
-                  col,
-                  'th',
-                  trRefs.current[colsIndex]?.offsetTop
-                )
+                const stickyColProps = getStickyColProps(col, 'th')
 
                 const cell = (
                   <th
@@ -80,6 +76,7 @@ export const TheadContent = forwardRef<HTMLDivElement | null, TheadContentProps>
                     {...stickyColProps}
                     style={{
                       ...stickyColProps.style,
+                      insetBlockStart: trRefs.current[colsIndex]?.offsetTop,
                       // 表头合并场景下，被合并的表头需要隐藏
                       display: col?.colSpan === 0 ? 'none' : undefined,
                     }}

--- a/packages/ui/table/src/use-table.ts
+++ b/packages/ui/table/src/use-table.ts
@@ -544,35 +544,29 @@ export const useTable = ({
     }, [] as FlattedTableColumnItemData[][])
   }, [mergedColumns1])
 
-  const getStickyColProps = useLatestCallback(
-    (column, type: 'th' | 'td' = 'td', stickyTop?: number) => {
-      const { rightStickyWidth, leftStickyWidth, align } = column
-      const sticky =
-        canScroll &&
-        (typeof rightStickyWidth !== 'undefined' || typeof leftStickyWidth !== 'undefined')
+  const getStickyColProps = useLatestCallback((column, type: 'th' | 'td' = 'td') => {
+    const { rightStickyWidth, leftStickyWidth, align } = column
+    const sticky =
+      canScroll &&
+      (typeof rightStickyWidth !== 'undefined' || typeof leftStickyWidth !== 'undefined')
 
-      const style: React.CSSProperties = {
-        textAlign: align,
-      }
-
-      if (sticky) {
-        style.position = 'sticky'
-        style.insetInlineEnd = rightStickyWidth + 'px'
-        style.insetInlineStart = leftStickyWidth + 'px'
-        // the value is same with v4
-        style.zIndex = type === 'th' ? 5 : 4
-
-        if (type === 'th' && stickyTop) {
-          style.insetBlockStart = stickyTop + 'px'
-        }
-      }
-
-      return {
-        style,
-        'data-sticky': setAttrStatus(sticky),
-      }
+    const style: React.CSSProperties = {
+      textAlign: align,
     }
-  )
+
+    if (sticky) {
+      style.position = 'sticky'
+      style.insetInlineEnd = rightStickyWidth + 'px'
+      style.insetInlineStart = leftStickyWidth + 'px'
+      // the value is same with v4
+      style.zIndex = type === 'th' ? 5 : 4
+    }
+
+    return {
+      style,
+      'data-sticky': setAttrStatus(sticky),
+    }
+  })
 
   const getTableHeaderProps = React.useCallback(() => {
     const style: React.CSSProperties = {

--- a/packages/ui/table/src/use-table.ts
+++ b/packages/ui/table/src/use-table.ts
@@ -544,34 +544,40 @@ export const useTable = ({
     }, [] as FlattedTableColumnItemData[][])
   }, [mergedColumns1])
 
-  const getStickyColProps = useLatestCallback((column) => {
-    const { rightStickyWidth, leftStickyWidth, align } = column
-    const sticky =
-      canScroll &&
-      (typeof rightStickyWidth !== 'undefined' || typeof leftStickyWidth !== 'undefined')
+  const getStickyColProps = useLatestCallback(
+    (column, type: 'th' | 'td' = 'td', stickyTop?: number) => {
+      const { rightStickyWidth, leftStickyWidth, align } = column
+      const sticky =
+        canScroll &&
+        (typeof rightStickyWidth !== 'undefined' || typeof leftStickyWidth !== 'undefined')
 
-    const style: React.CSSProperties = {
-      textAlign: align,
-    }
+      const style: React.CSSProperties = {
+        textAlign: align,
+      }
 
-    if (sticky) {
-      style.position = 'sticky'
-      style.right = rightStickyWidth + 'px'
-      style.left = leftStickyWidth + 'px'
-      // the value is same with v3
-      style.zIndex = 5
-    }
+      if (sticky) {
+        style.position = 'sticky'
+        style.insetInlineEnd = rightStickyWidth + 'px'
+        style.insetInlineStart = leftStickyWidth + 'px'
+        // the value is same with v4
+        style.zIndex = type === 'th' ? 5 : 4
 
-    return {
-      style,
-      'data-sticky': setAttrStatus(sticky),
+        if (type === 'th' && stickyTop) {
+          style.insetBlockStart = stickyTop + 'px'
+        }
+      }
+
+      return {
+        style,
+        'data-sticky': setAttrStatus(sticky),
+      }
     }
-  })
+  )
 
   const getTableHeaderProps = React.useCallback(() => {
     const style: React.CSSProperties = {
       position: sticky ? 'sticky' : 'relative',
-      top: sticky ? stickyTop : undefined,
+      insetBlockStart: sticky ? stickyTop : undefined,
       overflow: 'hidden',
       zIndex: sticky ? 10 : undefined,
     }


### PR DESCRIPTION
stretchHeight 模式下，使用的是单体 table 结构，之前的处理方式是将冻结列的表头和单元格的 z-index 设置为相同的值，所以当在 stretchHeight 模式下出现滑动时，下面的单元格会覆盖表头。
解决方案是将表头和单元格设置不同的层级。