### PR TITLE
fix(table): 修复标题过长时，列头宽度拉宽后无法缩小的问题 (5.0)

### DIFF
--- a/.changeset/swift-pillows-lick.md
+++ b/.changeset/swift-pillows-lick.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/hiui": patch
+"@hi-ui/table": patch
+---
+
+fix(table): 修复标题过长时，列头宽度拉宽后无法缩小的问题 (5.0)

--- a/packages/ui/table/src/hooks/use-col-width.ts
+++ b/packages/ui/table/src/hooks/use-col-width.ts
@@ -196,7 +196,9 @@ export const useColWidth = ({
     if (headerTableElement) {
       resizeObserver = new ResizeObserver(() => {
         const calcMinColWidths = Array.from(headerTableElement.childNodes).map((th, index) => {
-          const minColWidth = getGroupItemWidth(columns).minColWidths[index]
+          const { colWidths, minColWidths } = getGroupItemWidth(columns)
+          const colWidth = colWidths[index]
+          const minColWidth = minColWidths[index]
 
           // 如果设置了最小宽度，则直接使用最小宽度，否则使用标题宽度
           if (minColWidth !== undefined && minColWidth !== 0) {
@@ -208,6 +210,10 @@ export const useColWidth = ({
           )
           const childNode = Array.from(th.childNodes)[0]
           const childNodeWidth = (childNode as HTMLElement).offsetWidth + thPaddingLeft * 2
+
+          if (colWidth && colWidth < childNodeWidth) {
+            return colWidth
+          }
 
           return childNodeWidth || 40
         })


### PR DESCRIPTION
优化了列头最小宽度计算逻辑，当没有设置 minWidth 时，计算出的真实列宽大于设置的 width 时，将最小宽度设置为 width