### PR TITLE
refactor(table): 调整列宽计算逻辑，兼容表头分组和单元格合并场景 (5.0)

### DIFF
--- a/.changeset/tiny-trainers-film.md
+++ b/.changeset/tiny-trainers-film.md
@@ -1,0 +1,6 @@
+---
+"@hi-ui/hiui": patch
+"@hi-ui/table": patch
+---
+
+refactor(table): 调整列宽计算逻辑，兼容表头分组和单元格合并场景 (5.0)

--- a/packages/ui/table/src/TbodyContent.tsx
+++ b/packages/ui/table/src/TbodyContent.tsx
@@ -27,6 +27,7 @@ export const TbodyContent = forwardRef<HTMLDivElement | null, TbodyContentProps>
       measureRowElementRef,
       rowClassName,
       fixedToRow,
+      flattedColumnsWithoutChildren,
     } = useTableContext()
 
     const getRequiredProps = useLatestCallback(
@@ -88,25 +89,28 @@ export const TbodyContent = forwardRef<HTMLDivElement | null, TbodyContentProps>
     // 外层增加 div 作为滚动容器
     return (
       <tbody>
+        {/* 测量行，用于测量表格每列宽度 */}
+        <tr ref={measureRowElementRef} aria-hidden style={{ height: 0 }}>
+          {flattedColumnsWithoutChildren.map((column) => (
+            <td
+              key={column.id}
+              style={{
+                height: 0,
+                paddingTop: 0,
+                paddingBottom: 0,
+                borderTop: 'none',
+                borderBottom: 'none',
+              }}
+            />
+          ))}
+        </tr>
         {isArrayNonEmpty(transitionData) ? (
           <>
             {transitionData.map((row, index) => {
               return (
                 <TableRow
-                  ref={(el) => {
-                    // 当 el 的子节点数量和 columns 的数量相等时（考虑单元格合并的情况），并且measureRowElementRefNeedUpdate.current为true时，才更新measureRowElementRef
-                    if (
-                      el?.childNodes.length === columns.length &&
-                      measureRowElementRefNeedUpdate.current
-                    ) {
-                      measureRowElementRef.current = el
-                      measureRowElementRefNeedUpdate.current = false
-                    }
-                  }}
-                  // key={depth + index}
                   key={row.id}
                   className={cx(rowClassName?.(row, index), ...fixedToRowTopClassName(row, index))}
-                  // @ts-ignore
                   rowIndex={index}
                   rowData={row}
                   // expandedTree={isExpandTreeRows(row.id)}

--- a/packages/ui/table/src/hooks/use-col-width.ts
+++ b/packages/ui/table/src/hooks/use-col-width.ts
@@ -27,17 +27,19 @@ export const useColWidth = ({
 
   /**
    * 根据实际内容区（table 的第一行）渲染，再次精确收集并设置每列宽度
+   * 如果实际总宽度大于设置的宽度，则将多余的宽度平分到没有设置 fixed 的列上
    */
   const getWidths = useCallback(
     (measureRowElement: HTMLTableRowElement | null) => {
       if (measureRowElement && measureRowElement.childNodes) {
         // 超出的宽度，即每列真实的宽度超出设置的宽度的总和
         let exceedWidth = 0
+        const { flattedColumnsWithoutChildren, colWidths } = getGroupItemWidth(columns)
 
         let _realColumnsWidth = Array.from(measureRowElement.childNodes).map((node, index) => {
           const realWidth = (node as HTMLElement).offsetWidth || 60
-          const { fixed } = columns[index] ?? {}
-          const width = getGroupItemWidth(columns).colWidths[index]
+          const { fixed } = flattedColumnsWithoutChildren[index] ?? {}
+          const width = colWidths[index]
 
           // 如果该列设置了 fixed 并且真实宽度大于设置的 width 则设置为 width
           if (fixed && width && width < realWidth) {
@@ -50,10 +52,10 @@ export const useColWidth = ({
 
         // 如果有多余的宽度，则将多余的宽度平分到没有设置 fixed 的列上
         if (exceedWidth > 0) {
-          const noFixedColumns = columns.filter((item) => !item.fixed)
+          const noFixedColumns = flattedColumnsWithoutChildren.filter((item) => !item.fixed)
 
           _realColumnsWidth = _realColumnsWidth.map((item, index) => {
-            if (!columns[index]?.fixed) {
+            if (!flattedColumnsWithoutChildren[index]?.fixed) {
               return item + Math.floor(exceedWidth / noFixedColumns.length)
             }
             return item
@@ -184,7 +186,7 @@ export const useColWidth = ({
     null
   )
 
-  // 控制列最小可调整宽度
+  // 控制列最小可调整宽度，主要用于可拖拽调节列宽的场景，目前表头分组还不支持该功能
   const [minColWidths, setMinColWidths] = React.useState<number[]>(
     getGroupItemWidth(columns).minColWidths
   )
@@ -200,7 +202,7 @@ export const useColWidth = ({
           const colWidth = colWidths[index]
           const minColWidth = minColWidths[index]
 
-          // 如果设置了最小宽度，则直接使用最小宽度，否则使用标题宽度
+          // 如果设置了最小宽度，则直接使用最小宽度
           if (minColWidth !== undefined && minColWidth !== 0) {
             return minColWidth
           }
@@ -209,8 +211,10 @@ export const useColWidth = ({
             window.getComputedStyle(th as Element).getPropertyValue('padding-left')
           )
           const childNode = Array.from(th.childNodes)[0]
-          const childNodeWidth = (childNode as HTMLElement).offsetWidth + thPaddingLeft * 2
+          // 计算真实标题内容宽度
+          const childNodeWidth = (childNode as HTMLElement)?.offsetWidth + thPaddingLeft * 2
 
+          // 如果设置的标题宽度小于真实内容宽度，则使用设置的宽度，否则使用真实内容宽度
           if (colWidth && colWidth < childNodeWidth) {
             return colWidth
           }
@@ -229,35 +233,6 @@ export const useColWidth = ({
       resizeObserver?.disconnect()
     }
   }, [columns, columns.length, headerTableElement, resizable])
-
-  /**
-   *  控制列最小可调整宽度
-   */
-  const minColWidthMemo = React.useMemo(() => {
-    if (resizable && headerTableElement) {
-      const resizableHandlerWidth = 4
-      const _minColWidth = Array.from(headerTableElement.childNodes).map((th) => {
-        const thPaddingLeft = parseFloat(
-          window.getComputedStyle(th as Element).getPropertyValue('padding-left')
-        )
-        const childNodes = Array.from(th.childNodes)
-
-        return (
-          childNodes
-            .map((child) => (child as HTMLElement).offsetWidth)
-            .reduce((prev, next) => {
-              return prev + next
-            }) +
-          thPaddingLeft * 2 +
-          resizableHandlerWidth
-        )
-      })
-
-      return _minColWidth
-    }
-
-    return Array(columns.length).fill(0)
-  }, [columns.length, headerTableElement, resizable])
 
   /**
    * 列宽拖拽 resize，只处理拖拽线两边的列宽度

--- a/packages/ui/table/src/utils/index.ts
+++ b/packages/ui/table/src/utils/index.ts
@@ -64,12 +64,18 @@ export const setColumnsDefaultWidth = (columns: any, defaultWidth: any) => {
  */
 export const getGroupItemWidth = (
   columns: TableColumnItem[]
-): { colWidths: number[]; minColWidths: number[] } => {
+): {
+  colWidths: number[]
+  minColWidths: number[]
+  flattedColumnsWithoutChildren: TableColumnItem[]
+} => {
   const colWidths: number[] = []
   const minColWidths: number[] = []
+  const flattedColumnsWithoutChildren: TableColumnItem[] = []
 
   const dig = (column: TableColumnItem[]) => {
-    column.forEach(({ children, width, minWidth }) => {
+    column.forEach((item) => {
+      const { children, width, minWidth } = item
       if (Array.isArray(children)) {
         dig(children)
         return
@@ -81,6 +87,7 @@ export const getGroupItemWidth = (
 
       colWidths.push(colWidth)
       minColWidths.push(minColWidth)
+      flattedColumnsWithoutChildren.push(item)
     })
   }
 
@@ -89,6 +96,7 @@ export const getGroupItemWidth = (
   return {
     colWidths,
     minColWidths,
+    flattedColumnsWithoutChildren,
   }
 }
 

--- a/packages/ui/table/stories/resizable.stories.tsx
+++ b/packages/ui/table/stories/resizable.stories.tsx
@@ -4,6 +4,7 @@ import EllipsisTooltip from '@hi-ui/ellipsis-tooltip'
 
 /**
  * @title 可调节列宽
+ * @desc 表头分组不支持拖拽调节列宽
  */
 export const Resizable = () => {
   const [columns] = useState([

--- a/packages/ui/table/stories/sticky-footer.stories.tsx
+++ b/packages/ui/table/stories/sticky-footer.stories.tsx
@@ -77,7 +77,7 @@ export const StickyFooter = () => {
   ])
 
   const [paginationState, setPaginationState] = React.useState({
-    current: 0,
+    current: 1,
     data: data.slice(0, 5),
   })
 


### PR DESCRIPTION
tbody 下面加一个测量行，基于该行里面的单元格真实宽度来计算表格列宽，之所以这样处理是因为，之前是取 tbody 下面第一行 tr，如果该 tr 中的 td 有单元格合并的情况，会导致列宽计算逻辑中的列数不对，从而引发问题。