### PR TITLE
refactor(select): onChange 参数中 item 相关类型和值统一改为 SelectItemEventData (5.0)

### DIFF
--- a/packages/ui/check-select/src/use-check-select.ts
+++ b/packages/ui/check-select/src/use-check-select.ts
@@ -2,7 +2,7 @@ import React, { useCallback, useRef, useState } from 'react'
 import { useUncontrolledState } from '@hi-ui/use-uncontrolled-state'
 import { uniqBy } from '@hi-ui/array-utils'
 import { useCheck as useCheckDefault } from '@hi-ui/use-check'
-import { CheckSelectDataItem, CheckSelectItemEventData, CheckSelectMergedItem } from './types'
+import { CheckSelectItemEventData, CheckSelectMergedItem } from './types'
 import { useLatestCallback, useLatestRef } from '@hi-ui/use-latest'
 import { useCache } from '@hi-ui/use-cache'
 import { useFlattenData, useData } from './hooks'
@@ -78,12 +78,7 @@ export const useCheckSelect = ({
       const nextCheckedItems = usedItems.filter((item) => value.includes(item.id))
       setCheckedItems(nextCheckedItems)
 
-      tryChangeValue(
-        value,
-        // 处理脏数据
-        changedItems.map((item) => ('raw' in item ? item.raw : item)),
-        nextCheckedItems.map((item) => ('raw' in item ? item.raw : item))
-      )
+      tryChangeValue(value, changedItems, nextCheckedItems)
 
       // 每次更新 value 时，同步更新下 cacheData
       updateCacheData(nextCheckedItems)
@@ -127,8 +122,8 @@ export interface UseCheckSelectProps {
    */
   onChange?: (
     value: React.ReactText[],
-    changedItems: CheckSelectDataItem[],
-    checkedItems: CheckSelectDataItem[]
+    changedItems: CheckSelectItemEventData[],
+    checkedItems: CheckSelectItemEventData[]
   ) => void
   /**
    * 选中值时回调。暂不对外暴露

--- a/packages/ui/select/src/use-select.ts
+++ b/packages/ui/select/src/use-select.ts
@@ -28,7 +28,7 @@ export const useSelect = ({
     allowSelect,
     selectedId: value,
     onSelect: (value: React.ReactText, item: SelectItemEventData) => {
-      tryChangeValue(value, item.raw)
+      tryChangeValue(value, item)
       onSelectProp?.(value, item)
     },
   })


### PR DESCRIPTION
和其他组件类型保持一致